### PR TITLE
Fix/tao 8721/update navigation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,6 +35,7 @@ return [
         'tao' => '>=38.6.0',
         'taoLti' => '>=10.1.0',
         'ltiDeliveryProvider' => '>=9.2.0',
+        'taoQtiTest' => '>=34.6.0',
     ],
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoReviewManager',
     'acl' => [

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.2.0',
+    'version' => '1.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -68,6 +68,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.6.0');
         }
 
-        $this->skip('0.6.0', '1.2.0');
+        $this->skip('0.6.0', '1.2.1');
     }
 }

--- a/views/js/review/plugins/navigation/next-prev/plugin.js
+++ b/views/js/review/plugins/navigation/next-prev/plugin.js
@@ -52,8 +52,7 @@ define([
          */
         init() {
             const testRunner = this.getTestRunner();
-            const testData = testRunner.getTestData();
-            const testConfig = testData && testData.config || {};
+            const testConfig = testRunner.getConfig();
             const pluginShortcuts = (testConfig.shortcuts || {})[this.getName()] || {};
 
             /**

--- a/views/js/review/provider/qtiTestReviewProvider.js
+++ b/views/js/review/provider/qtiTestReviewProvider.js
@@ -154,10 +154,9 @@ define([
                     this.trigger('enabletools enablenav');
                 })
                 .on('move', function (direction, scope, ref) {
-                    const testData = this.getTestData();
                     const testContext = this.getTestContext();
                     const testMap = this.getTestMap();
-                    const testNavigator = testNavigatorFactory(testData, testContext, testMap);
+                    const testNavigator = testNavigatorFactory(testContext, testMap);
                     const newTestContext = testNavigator.navigate(direction, scope || 'item', ref);
                     this.unloadItem(testContext.itemIdentifier);
                     this.setTestContext(newTestContext);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8721

Fix the navigation broken since the update on the test runner API.

Impacted unit test:
- `taoReview/views/js/test/review/provider/qtiTestReviewProvider/test.html`
- `taoReview/views/js/test/review/plugins/navigation/next-prev/plugin/test.html`
- `taoReview/views/js/test/review/plugins/navigation/review-panel/plugin/test.html`

To launch tests:
```
cd tao/views/build
npx grunt connect:dev taoreviewtest
```