### PR TITLE
Feature/tao 8928/make navigator support filtered jumps table

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.4.0',
+    'version' => '1.5.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -68,6 +68,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.6.0');
         }
 
-        $this->skip('0.6.0', '1.4.0');
+        $this->skip('0.6.0', '1.5.0');
     }
 }

--- a/views/js/review/plugins/navigation/next-prev/plugin.js
+++ b/views/js/review/plugins/navigation/next-prev/plugin.js
@@ -95,19 +95,13 @@ define([
                 const buttons = buttonsFactory(this.getAreaBroker().getNavigationArea());
 
                 /**
-                 * Get the amount of navigable items
-                 * @returns {Number}
-                 */
-                const getItemsCount = () => (mapHelper.getJumps(testRunner.getTestMap()) || []).length;
-
-                /**
                  * Check if the "Next" functionality should be available or not
                  * @returns {Boolean}
                  */
                 const canDoNext = () => {
-                    const itemsCount = getItemsCount();
+                    const last = _.findLast(mapHelper.getJumps(testRunner.getTestMap()), jump => jump && jump.identifier);
                     const context = testRunner.getTestContext();
-                    return itemsCount && context.itemPosition < itemsCount - 1;
+                    return last && context.itemPosition < last.position;
                 };
 
                 /**
@@ -115,9 +109,9 @@ define([
                  * @returns {Boolean}
                  */
                 const canDoPrevious = () => {
-                    const itemsCount = getItemsCount();
+                    const first = _.find(mapHelper.getJumps(testRunner.getTestMap()), jump => jump && jump.identifier);
                     const context = testRunner.getTestContext();
-                    return itemsCount && context.itemPosition;
+                    return first && context.itemPosition > first.position;
                 };
 
                 /**
@@ -160,7 +154,7 @@ define([
 
                 // reflect the test runner state to the navigation buttons and performs the navigation on demand
                 testRunner
-                    .on('loaditem', toggle)
+                    .on('loaditem testmapchange', toggle)
                     .on('nav-next', doNext)
                     .on('nav-prev', doPrevious)
                     .on(`plugin-show.${this.getName()}`, () => buttons.show())

--- a/views/js/review/plugins/navigation/review-panel/plugin.js
+++ b/views/js/review/plugins/navigation/review-panel/plugin.js
@@ -87,13 +87,11 @@ define([
 
                 // reflect the filter to the map
                 navigationDataService
-                    .on('mapfilter', filteredMap => {
-                        testRunner.setTestMap(filteredMap);
-                        reviewPanel.setData(filteredMap);
-                    });
+                    .on('mapfilter', filteredMap => testRunner.setTestMap(filteredMap));
 
                 // reflect the test runner state to the review panel
                 testRunner
+                    .on('testmapchange', testMap => reviewPanel.setData(testMap))
                     .on('loaditem', itemRef => reviewPanel.setActiveItem(itemRef))
                     .on(`plugin-show.${this.getName()}`, () => reviewPanel.show())
                     .on(`plugin-hide.${this.getName()}`, () => reviewPanel.hide())

--- a/views/js/review/provider/qtiTestReviewProvider.js
+++ b/views/js/review/provider/qtiTestReviewProvider.js
@@ -31,7 +31,7 @@ define([
     'taoQtiTest/runner/ui/toolbox/toolbox',
     'taoQtiItem/runner/qtiItemRunner',
     'taoQtiTest/runner/config/assetManager',
-    'taoQtiTest/runner/navigator/navigator',
+    'taoReview/review/services/navigator',
     'tpl!taoReview/review/provider/tpl/qtiTestReviewProvider'
 ], function (
     $,
@@ -155,7 +155,6 @@ define([
                         const where = e.target.dataset.area;
                         areaBroker.getArea(where).addClass('focused');
                     }
-                    
                 });
                 container.on('focusout', (e) => {
                     if (e.target.classList.contains('jumplink')){
@@ -163,8 +162,9 @@ define([
                         areaBroker.getArea(where).removeClass('focused');
                     }
                 });
-            }
+            };
             createJumplinks(areaBroker.getContainer().find('.jumplinks'));
+
             /*
              * Install behavior on events
              */

--- a/views/js/review/provider/qtiTestReviewProvider.js
+++ b/views/js/review/provider/qtiTestReviewProvider.js
@@ -72,6 +72,20 @@ define([
          * Installation of the provider, called during test runner init phase.
          */
         install() {
+            // eventify the test map update
+            const defaultSetTestMap = this.setTestMap;
+            this.setTestMap = (...args) => {
+                const result = defaultSetTestMap.apply(this, args);
+
+                /**
+                 * @event testmapchange
+                 * @param {testMap} testMap
+                 */
+                this.trigger('testmapchange', this.getTestMap());
+
+                return result;
+            };
+
             const {plugins} = this.getConfig().options || {};
             if (plugins) {
                 _.forEach(this.getPlugins(), plugin => {

--- a/views/js/review/services/navigator.js
+++ b/views/js/review/services/navigator.js
@@ -42,31 +42,44 @@ define([
         return Object.assign({}, navigator, {
             /**
              * Navigate to the next item
-             * @returns {testContext} the new test context
+             * @returns {testContext|Boolean} the new test context
              */
             nextItem() {
-                const itemPosition = testContext.itemPosition + 1;
-                return testContextBuilder.buildTestContextFromPosition(testContext, testMap, itemPosition);
+                const next = _.find(mapHelper.getJumps(testMap), jump => jump && jump.position > testContext.itemPosition);
+                if (next) {
+                    return testContextBuilder.buildTestContextFromPosition(testContext, testMap, next.position);
+                }
+
+                return false;
             },
 
             /**
              * Navigate to the next item
-             * @returns {testContext} the new test context
+             * @returns {testContext|Boolean} the new test context
              */
             previousItem() {
-                const itemPosition = testContext.itemPosition - 1;
-                return testContextBuilder.buildTestContextFromPosition(testContext, testMap, itemPosition);
+                const prev = _.findLast(mapHelper.getJumps(testMap), jump => jump && jump.position < testContext.itemPosition);
+                if (prev) {
+                    return testContextBuilder.buildTestContextFromPosition(testContext, testMap, prev.position);
+                }
+
+                return false;
             },
 
             /**
              * Navigate to the next item
-             * @returns {testContext} the new test context
+             * @returns {testContext|Boolean} the new test context
              */
             nextSection() {
                 const sectionStats = mapHelper.getSectionStats(testMap, testContext.sectionId);
                 const section = mapHelper.getSection(testMap, testContext.sectionId);
                 const itemPosition = section.position + sectionStats.total;
-                return testContextBuilder.buildTestContextFromPosition(testContext, testMap, itemPosition);
+                const next = _.find(mapHelper.getJumps(testMap), jump => jump && jump.position >= itemPosition);
+                if (next) {
+                    return testContextBuilder.buildTestContextFromPosition(testContext, testMap, next.position);
+                }
+
+                return false;
             }
         });
     }

--- a/views/js/review/services/navigator.js
+++ b/views/js/review/services/navigator.js
@@ -1,0 +1,75 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA ;
+ */
+
+/**
+ * Extends the navigator service supplied by the QTI test runner,
+ * supporting filtered jumps tables (created after test map filtering).
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'taoQtiTest/runner/helpers/map',
+    'taoQtiTest/runner/helpers/testContextBuilder',
+    'taoQtiTest/runner/navigator/navigator'
+], function (_, mapHelper, testContextBuilder, runnerNavigatorFactory) {
+
+    /**
+     * Gives you a navigator
+     * @param {Object} testContext
+     * @param {Object} testMap
+     * @returns {Object} the navigator
+     * @throws {TypeError} if the given parameters aren't objects
+     */
+    function navigatorFactory(testContext, testMap) {
+        const navigator = runnerNavigatorFactory(testContext, testMap);
+
+        // extends the default navigator, taking care of corrupted jumps table
+        return Object.assign({}, navigator, {
+            /**
+             * Navigate to the next item
+             * @returns {testContext} the new test context
+             */
+            nextItem() {
+                const itemPosition = testContext.itemPosition + 1;
+                return testContextBuilder.buildTestContextFromPosition(testContext, testMap, itemPosition);
+            },
+
+            /**
+             * Navigate to the next item
+             * @returns {testContext} the new test context
+             */
+            previousItem() {
+                const itemPosition = testContext.itemPosition - 1;
+                return testContextBuilder.buildTestContextFromPosition(testContext, testMap, itemPosition);
+            },
+
+            /**
+             * Navigate to the next item
+             * @returns {testContext} the new test context
+             */
+            nextSection() {
+                const sectionStats = mapHelper.getSectionStats(testMap, testContext.sectionId);
+                const section = mapHelper.getSection(testMap, testContext.sectionId);
+                const itemPosition = section.position + sectionStats.total;
+                return testContextBuilder.buildTestContextFromPosition(testContext, testMap, itemPosition);
+            }
+        });
+    }
+
+    return navigatorFactory;
+});

--- a/views/js/test/review/component/qtiTestReviewComponent/test.js
+++ b/views/js/test/review/component/qtiTestReviewComponent/test.js
@@ -26,6 +26,7 @@ define([
     'json!taoReview/test/mocks/item-1.json',
     'json!taoReview/test/mocks/item-2.json',
     'json!taoReview/test/mocks/item-3.json',
+    'json!taoReview/test/mocks/item-4.json',
     'json!taoReview/test/mocks/testData.json',
     'json!taoReview/test/mocks/testContext.json',
     'json!taoReview/test/mocks/testMap.json',
@@ -38,6 +39,7 @@ define([
     itemData1,
     itemData2,
     itemData3,
+    itemData4,
     testData,
     testContext,
     testMap,
@@ -200,15 +202,23 @@ define([
             fullPage: false,
             readOnly: true,
             plugins: [{
+                module: 'taoReview/review/plugins/navigation/review-panel/plugin',
+                bundle: 'taoReview/loader/qtiReview.min',
+                category: 'navigation'
+            }, {
                 module: 'taoReview/review/plugins/navigation/next-prev/plugin',
                 bundle: 'taoReview/loader/qtiReview.min',
                 category: 'navigation'
+            }, {
+                module: 'taoReview/review/plugins/content/item-answer/plugin',
+                bundle: 'taoReview/loader/qtiReview.min',
+                category: 'content'
             }]
         };
 
         assert.expect(1);
 
-        $.mockjax({
+        $.mockjax([{
             url: '/init*',
             responseText: {
                 success: true,
@@ -218,8 +228,7 @@ define([
                 testMap: testMap,
                 testResponses: testResponses
             }
-        });
-        $.mockjax({
+        }, {
             url: '/getItem*item-1',
             responseText: {
                 success: true,
@@ -230,8 +239,7 @@ define([
                 baseUrl: '',
                 state: {}
             }
-        });
-        $.mockjax({
+        }, {
             url: '/getItem*item-2',
             responseText: {
                 success: true,
@@ -242,8 +250,7 @@ define([
                 baseUrl: '',
                 state: {}
             }
-        });
-        $.mockjax({
+        }, {
             url: '/getItem*item-3',
             responseText: {
                 success: true,
@@ -254,10 +261,22 @@ define([
                 baseUrl: '',
                 state: {}
             }
-        });
+        }, {
+            url: '/getItem*item-4',
+            responseText: {
+                success: true,
+                content: {
+                    type: 'qti',
+                    data: itemData4
+                },
+                baseUrl: '',
+                state: {}
+            }
+        }]);
 
         qtiTestReviewFactory($container, config)
             .on('error', err => {
+                console.error(err);
                 assert.pushResult({
                     result: false,
                     message: err

--- a/views/js/test/review/plugins/navigation/next-prev/plugin/test.html
+++ b/views/js/test/review/plugins/navigation/next-prev/plugin/test.html
@@ -41,6 +41,7 @@
             <div id="fixture-api"></div>
             <div id="fixture-render"></div>
             <div id="fixture-navigation"></div>
+            <div id="fixture-filtered"></div>
         </div>
         <div id="visual-test"></div>
     </body>

--- a/views/js/test/review/plugins/navigation/review-panel/plugin/test.js
+++ b/views/js/test/review/plugins/navigation/review-panel/plugin/test.js
@@ -59,6 +59,14 @@ define([
                     control: $('.footer', $fixture)
                 });
             },
+            install() {
+                const defaultSetTestMap = this.setTestMap;
+                this.setTestMap = (...args) => {
+                    const result = defaultSetTestMap.apply(this, args);
+                    this.trigger('testmapchange', this.getTestMap());
+                    return result;
+                };
+            },
             init() {
                 this.setTestMap(testMap);
             }

--- a/views/js/test/review/provider/qtiTestReviewProvider/test.html
+++ b/views/js/test/review/provider/qtiTestReviewProvider/test.html
@@ -53,6 +53,8 @@
             <div id="fixture-render"></div>
             <div id="fixture-item"></div>
             <div id="fixture-navigate"></div>
+            <div id="fixture-jumplinks"></div>
+            <div id="fixture-testmapchange"></div>
         </div>
         <div id="visual-test"></div>
     </body>

--- a/views/js/test/review/provider/qtiTestReviewProvider/test.js
+++ b/views/js/test/review/provider/qtiTestReviewProvider/test.js
@@ -607,9 +607,9 @@ define([
     }]).test('tab navigation', (data, assert) => {
         assert.expect(5);
         const ready = assert.async();
-        const $fixture = $('#fixture-render');
+        const $fixture = $('#fixture-jumplinks');
         const mockProxy = {
-            name: 'renderProxy',
+            name: 'jumplinksProxy',
             init() {
                 assert.ok(true, 'The init method has been called on the proxy');
                 return Promise.resolve({
@@ -648,6 +648,53 @@ define([
                         assert.ok(false, `Error in init method: ${err.message}`);
                         runner.destroy();
                     });
+            })
+            .on('destroy', ready)
+            .init();
+    });
+
+    QUnit.test('testmapchange event', assert => {
+        assert.expect(3);
+        const ready = assert.async();
+        const $fixture = $('#fixture-testmapchange');
+        const mockProxy = {
+            name: 'testmapchangeProxy',
+            init() {
+                assert.ok(true, 'The init method has been called on the proxy');
+                return Promise.resolve({
+                    success: true
+                });
+            }
+        };
+        const config = {
+            renderTo: $fixture,
+            proxyProvider: mockProxy.name
+        };
+        proxyFactory.registerProvider(mockProxy.name, mockProxy);
+        const runner = runnerFactory('qtiTestReviewProvider', [], config)
+            .on('ready', () => {
+                assert.equal(runner.getTestMap(), null, 'No test map available yet');
+                Promise.resolve()
+                    .then(() => new Promise(resolve => {
+                        runner
+                            .on('.test')
+                            .on('testmapchange.test', newTestMap => {
+                                assert.deepEqual(newTestMap, testMap, 'The test map has been changed');
+                                resolve();
+                            })
+                            .setTestMap(testMap);
+                    }))
+                    .then(() => {
+                        runner
+                            .off('.test');
+                    })
+                    .catch(err => {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(() => runner.on('.test').destroy());
             })
             .on('destroy', ready)
             .init();

--- a/views/js/test/review/services/navigator/test.html
+++ b/views/js/test/review/services/navigator/test.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Review - Navigator Service</title>
+    <base href="../../../../../../../../../tao/views/"/>
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+
+    <script type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function () {
+            requirejs.config({
+                "config": {
+                    "core/request" : {
+                        'noToken' : true
+                    }
+                }
+            });
+
+            //load the test
+            require(['taoReview/test/review/services/navigator/test'], function () {
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/review/services/navigator/test.js
+++ b/views/js/test/review/services/navigator/test.js
@@ -1,0 +1,316 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'taoReview/review/services/navigator',
+    'json!taoReview/test/review/services/navigator/testMap.json',
+    'json!taoReview/test/review/services/navigator/testContexts.json'
+], function (testNavigator, testMap, testContexts) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', assert => {
+        assert.expect(1);
+
+        assert.equal(typeof testNavigator, 'function', 'The navigator is a function');
+    });
+
+    QUnit.test('factory', assert => {
+        assert.expect(5);
+
+        assert.throws(testNavigator, TypeError, 'factory called without parameter');
+        assert.throws(() => testNavigator({}), TypeError, 'factory called without all parameters');
+        assert.throws(() => testNavigator(testContexts.context1), TypeError, 'factory called without all parameters');
+
+        assert.equal(typeof testNavigator({}, testMap), 'object', 'The factory creates an object');
+        assert.notEqual(testNavigator({}, testMap), testNavigator({}, testMap), 'The factory creates new objects');
+    });
+
+    QUnit.cases.init([
+        {title: 'navigate'},
+        {title: 'nextItem'},
+        {title: 'previousItem'},
+        {title: 'nextSection'},
+        {title: 'jumpItem'}
+    ]).test('Method ', (data, assert) => {
+        assert.expect(1);
+
+        assert.equal(
+            typeof testNavigator({}, testMap)[data.title],
+            'function',
+            `The instance exposes a "${data.title}" method`
+        );
+    });
+
+    QUnit.module('navigator.nextItem');
+
+    QUnit.test('is moving to the next item inside a section', assert => {
+        assert.expect(6);
+
+        const updatedContext = testNavigator(testContexts.context1, testMap).nextItem();
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-2',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 1, 'The updated context contains the correct item position');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-1',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
+        assert.deepEqual(updatedContext.timeConstraints, [], 'The updated context has no time constraints');
+        assert.deepEqual(
+            updatedContext.options,
+            {
+                reviewScreen: true,
+                markReview: true,
+                endTestWarning: true,
+                zoom: true,
+                allowComment: false,
+                allowSkipping: true,
+                exitButton: false,
+                logoutButton: false
+            },
+            'The updated context contains the correct options'
+        );
+    });
+
+    QUnit.test('is moving to the next item over a section', assert => {
+        assert.expect(6);
+
+        const updatedContext = testNavigator(testContexts.context2, testMap).nextItem();
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-4',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 3, 'The updated context contains the correct item position');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-2',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
+        assert.deepEqual(
+            updatedContext.timeConstraints,
+            [
+                {
+                    label: 'Rubric block',
+                    source: 'assessmentSection-2',
+                    seconds: '60',
+                    extraTime: 0,
+                    allowLateSubmission: false,
+                    qtiClassName: 'assessmentSection'
+                }
+            ],
+            'The updated context contains the new section time constraints'
+        );
+        assert.deepEqual(
+            updatedContext.options,
+            {
+                calculator: true,
+                zoom: true,
+                fooBarBaz: true,
+                awesomeCategory: true,
+                allowComment: false,
+                allowSkipping: true,
+                exitButton: false,
+                logoutButton: false
+            },
+            'The updated context contains the correct options'
+        );
+    });
+
+    QUnit.test('is moving to the next item over a testPart', assert => {
+        assert.expect(6);
+
+        const updatedContext = testNavigator(testContexts.context3, testMap).nextItem();
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-15',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 14, 'The updated context contains the correct item position');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-6',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-2', 'The updated context contains the correct test part id');
+        assert.equal(updatedContext.isLinear, true, 'The updated context contains the correct isLinear option');
+        assert.equal(updatedContext.itemAnswered, true, 'The item has been answered since the test part is linear');
+    });
+
+    QUnit.test('is moving to the next item over timed sections', assert => {
+        assert.expect(6);
+
+        const updatedContext = testNavigator(testContexts.context4, testMap).nextItem();
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-7',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 6, 'The updated context contains the correct item position');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-3',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
+        assert.equal(updatedContext.isLinear, false, 'The updated context contains the correct isLinear option');
+        assert.deepEqual(
+            updatedContext.timeConstraints,
+            [
+                {
+                    label: 'Timed section',
+                    source: 'assessmentSection-3',
+                    seconds: '90',
+                    extraTime: 0,
+                    allowLateSubmission: false,
+                    qtiClassName: 'assessmentSection'
+                }
+            ],
+            'The updated context contains the new section time constraints'
+        );
+    });
+
+    QUnit.test('is moving to the next item to the end', assert => {
+        assert.expect(1);
+
+        const updatedContext = testNavigator(testContexts.context5, testMap).nextItem();
+        assert.equal(updatedContext, false, 'There is no next item');
+    });
+
+    QUnit.module('navigator.previousItem');
+
+    QUnit.test('is moving to the previous item inside a section', assert => {
+        assert.expect(5);
+
+        const updatedContext = testNavigator(testContexts.context2, testMap).previousItem();
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-2',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 1, 'The updated context contains the correct item position');
+        assert.equal(updatedContext.itemAnswered, true, 'The item has already been answered');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-1',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
+    });
+
+    QUnit.module('navigator.nextSection');
+
+    QUnit.test('is moving to the next section', assert => {
+        assert.expect(6);
+
+        const updatedContext = testNavigator(testContexts.context4, testMap).nextSection();
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-7',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 6, 'The updated context contains the correct item position');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-3',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
+        assert.equal(updatedContext.isLinear, false, 'The updated context contains the correct isLinear option');
+        assert.deepEqual(
+            updatedContext.timeConstraints,
+            [
+                {
+                    label: 'Timed section',
+                    source: 'assessmentSection-3',
+                    seconds: '90',
+                    extraTime: 0,
+                    allowLateSubmission: false,
+                    qtiClassName: 'assessmentSection'
+                }
+            ],
+            'The updated context contains the new section time constraints'
+        );
+    });
+
+    QUnit.module('navigator.jumpItem');
+
+    QUnit.test('is jumping to the 2nd previous item', assert => {
+        assert.expect(5);
+
+        const updatedContext = testNavigator(testContexts.context4, testMap).jumpItem(3);
+
+        assert.equal(
+            updatedContext.itemIdentifier,
+            'item-4',
+            'The updated context contains the correct item identifier'
+        );
+        assert.equal(updatedContext.itemPosition, 3, 'The updated context contains the correct item position');
+        assert.equal(
+            updatedContext.sectionId,
+            'assessmentSection-2',
+            'The updated context contains the correct section id'
+        );
+        assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
+        assert.deepEqual(
+            updatedContext.timeConstraints,
+            [
+                {
+                    label: 'Rubric block',
+                    source: 'assessmentSection-2',
+                    seconds: '60',
+                    extraTime: 0,
+                    allowLateSubmission: false,
+                    qtiClassName: 'assessmentSection'
+                }
+            ],
+            'The updated context contains the new section time constraints'
+        );
+    });
+
+    QUnit.module('navigator.navigate');
+
+    QUnit.test('executes the correct movement', assert => {
+        const aTestNaviagtor = testNavigator(testContexts.context4, testMap);
+
+        assert.expect(5);
+
+        assert.deepEqual(aTestNaviagtor.navigate('next', 'item'), aTestNaviagtor.nextItem());
+        assert.deepEqual(aTestNaviagtor.navigate('previous', 'item'), aTestNaviagtor.previousItem());
+        assert.deepEqual(aTestNaviagtor.navigate('next', 'section'), aTestNaviagtor.nextSection());
+        assert.deepEqual(aTestNaviagtor.navigate('jump', 'item', 3), aTestNaviagtor.jumpItem(3));
+
+        assert.equal(typeof aTestNaviagtor.navigate('forward', 'test-part', 3), 'undefined');
+    });
+});

--- a/views/js/test/review/services/navigator/test.js
+++ b/views/js/test/review/services/navigator/test.js
@@ -22,8 +22,9 @@
 define([
     'taoReview/review/services/navigator',
     'json!taoReview/test/review/services/navigator/testMap.json',
+    'json!taoReview/test/review/services/navigator/testMapFiltered.json',
     'json!taoReview/test/review/services/navigator/testContexts.json'
-], function (testNavigator, testMap, testContexts) {
+], function (testNavigator, testMap, testMapFiltered, testContexts) {
     'use strict';
 
     QUnit.module('API');
@@ -302,15 +303,56 @@ define([
     QUnit.module('navigator.navigate');
 
     QUnit.test('executes the correct movement', assert => {
-        const aTestNaviagtor = testNavigator(testContexts.context4, testMap);
+        const aTestNavigator = testNavigator(testContexts.context4, testMap);
+        let newTestContext;
 
-        assert.expect(5);
+        assert.expect(9);
 
-        assert.deepEqual(aTestNaviagtor.navigate('next', 'item'), aTestNaviagtor.nextItem());
-        assert.deepEqual(aTestNaviagtor.navigate('previous', 'item'), aTestNaviagtor.previousItem());
-        assert.deepEqual(aTestNaviagtor.navigate('next', 'section'), aTestNaviagtor.nextSection());
-        assert.deepEqual(aTestNaviagtor.navigate('jump', 'item', 3), aTestNaviagtor.jumpItem(3));
+        newTestContext = aTestNavigator.navigate('next', 'item');
+        assert.deepEqual(newTestContext, aTestNavigator.nextItem());
+        assert.equal(newTestContext.itemPosition, 6);
 
-        assert.equal(typeof aTestNaviagtor.navigate('forward', 'test-part', 3), 'undefined');
+        newTestContext = aTestNavigator.navigate('previous', 'item');
+        assert.deepEqual(newTestContext, aTestNavigator.previousItem());
+        assert.equal(newTestContext.itemPosition, 4);
+
+        newTestContext = aTestNavigator.navigate('next', 'section');
+        assert.deepEqual(newTestContext, aTestNavigator.nextSection());
+        assert.equal(newTestContext.itemPosition, 6);
+
+        newTestContext = aTestNavigator.navigate('jump', 'item', 3);
+        assert.deepEqual(newTestContext, aTestNavigator.jumpItem(3));
+        assert.equal(newTestContext.itemPosition, 3);
+
+        assert.equal(typeof aTestNavigator.navigate('forward', 'test-part', 3), 'undefined');
+    });
+
+    QUnit.test('still work with a filtered map', assert => {
+        const aTestNavigator = testNavigator(testContexts.context4, testMapFiltered);
+        let newTestContext;
+
+        assert.expect(11);
+
+        newTestContext = aTestNavigator.navigate('next', 'item');
+        assert.deepEqual(newTestContext, aTestNavigator.nextItem());
+        assert.equal(newTestContext.itemPosition, 7);
+
+        newTestContext = aTestNavigator.navigate('previous', 'item');
+        assert.deepEqual(newTestContext, aTestNavigator.previousItem());
+        assert.equal(newTestContext.itemPosition, 0);
+
+        newTestContext = aTestNavigator.navigate('next', 'section');
+        assert.deepEqual(newTestContext, aTestNavigator.nextSection());
+        assert.equal(newTestContext.itemPosition, 7);
+
+        newTestContext = aTestNavigator.navigate('jump', 'item', 14);
+        assert.deepEqual(newTestContext, aTestNavigator.jumpItem(14));
+        assert.equal(newTestContext.itemPosition, 14);
+
+        newTestContext = aTestNavigator.navigate('jump', 'item', 3);
+        assert.deepEqual(newTestContext, aTestNavigator.jumpItem(3));
+        assert.equal(newTestContext, false);
+
+        assert.equal(typeof aTestNavigator.navigate('forward', 'test-part', 3), 'undefined');
     });
 });

--- a/views/js/test/review/services/navigator/testContexts.json
+++ b/views/js/test/review/services/navigator/testContexts.json
@@ -1,0 +1,182 @@
+{
+  "context1": {
+    "state": 1,
+    "remainingAttempts": -1,
+    "isLinear": false,
+    "attempt": 1,
+    "isTimeout": false,
+    "itemIdentifier": "item-1",
+    "itemSessionState": 1,
+    "needMapUpdate": false,
+    "isLast": false,
+    "itemPosition": 0,
+    "itemAnswered": false,
+    "timeConstraints": [],
+    "extraTime": {
+      "total": 0,
+      "consumed": 0,
+      "remaining": 0
+    },
+    "testPartId": "testPart-1",
+    "sectionId": "assessmentSection-1",
+    "sectionTitle": "Basic section",
+    "sectionPause": false,
+    "isDeepestSectionVisible": true,
+    "canMoveBackward": false,
+    "preventEmptyResponses": false,
+    "hasFeedbacks": false,
+    "options": {
+      "allowComment": false,
+      "allowSkipping": true,
+      "exitButton": false,
+      "logoutButton": false
+    }
+  },
+  "context2": {
+    "state": 1,
+    "remainingAttempts": -1,
+    "isLinear": false,
+    "attempt": 1,
+    "isTimeout": false,
+    "itemIdentifier": "item-3",
+    "itemSessionState": 1,
+    "needMapUpdate": false,
+    "isLast": false,
+    "itemPosition": 2,
+    "itemAnswered": false,
+    "timeConstraints": [],
+    "extraTime": {
+      "total": 0,
+      "consumed": 0,
+      "remaining": 0
+    },
+    "testPartId": "testPart-1",
+    "sectionId": "assessmentSection-1",
+    "sectionTitle": "Basic section",
+    "sectionPause": false,
+    "isDeepestSectionVisible": true,
+    "canMoveBackward": true,
+    "preventEmptyResponses": false,
+    "hasFeedbacks": false,
+    "options": {
+      "allowComment": false,
+      "allowSkipping": true,
+      "exitButton": false,
+      "logoutButton": false
+    }
+  },
+  "context3": {
+    "state": 1,
+    "remainingAttempts": -1,
+    "isLinear": false,
+    "attempt": 1,
+    "isTimeout": false,
+    "itemIdentifier": "item-14",
+    "itemSessionState": 1,
+    "needMapUpdate": false,
+    "isLast": false,
+    "itemPosition": 13,
+    "itemAnswered": false,
+    "timeConstraints": [],
+    "extraTime": {
+      "total": 0,
+      "consumed": 0,
+      "remaining": 0
+    },
+    "testPartId": "testPart-1",
+    "sectionId": "assessmentSection-5",
+    "sectionTitle": "Jump section",
+    "sectionPause": false,
+    "isDeepestSectionVisible": true,
+    "canMoveBackward": true,
+    "preventEmptyResponses": false,
+    "hasFeedbacks": false,
+    "options": {
+      "allowComment": false,
+      "allowSkipping": true,
+      "exitButton": false,
+      "logoutButton": false,
+      "reviewScreen": true
+    }
+  },
+  "context4": {
+    "state": 1,
+    "remainingAttempts": -1,
+    "isLinear": false,
+    "attempt": 1,
+    "isTimeout": false,
+    "itemIdentifier": "item-6",
+    "itemSessionState": 1,
+    "needMapUpdate": false,
+    "isLast": false,
+    "itemPosition": 5,
+    "itemAnswered": false,
+    "timeConstraints": [{
+      "label": "Item 3",
+      "source": "item-6",
+      "seconds": "10",
+      "extraTime": 0,
+      "allowLateSubmission": false,
+      "qtiClassName": "assessmentItemRef"
+    }, {
+      "label": "Rubric block",
+      "source": "assessmentSection-2",
+      "seconds": "60",
+      "extraTime": 0,
+      "allowLateSubmission": false,
+      "qtiClassName": "assessmentSection"
+    }],
+    "extraTime": {
+      "total": 0,
+      "consumed": 0,
+      "remaining": 0
+    },
+    "testPartId": "testPart-1",
+    "sectionId": "assessmentSection-2",
+    "sectionTitle": "Rubric block",
+    "sectionPause": false,
+    "isDeepestSectionVisible": true,
+    "canMoveBackward": true,
+    "preventEmptyResponses": false,
+    "hasFeedbacks": false,
+    "options": {
+      "allowComment": false,
+      "allowSkipping": true,
+      "exitButton": false,
+      "logoutButton": false
+    }
+  },
+  "context5": {
+    "state": 1,
+    "remainingAttempts": -1,
+    "isLinear": true,
+    "attempt": 1,
+    "isTimeout": false,
+    "itemIdentifier": "item-17",
+    "itemSessionState": 1,
+    "needMapUpdate": false,
+    "isLast": true,
+    "itemPosition": 16,
+    "itemAnswered": false,
+    "timeConstraints": [],
+    "extraTime": {
+      "total": 0,
+      "consumed": 0,
+      "remaining": 0
+    },
+    "testPartId": "testPart-2",
+    "sectionId": "assessmentSection-6",
+    "sectionTitle": "Section 1",
+    "sectionPause": false,
+    "isDeepestSectionVisible": true,
+    "canMoveBackward": false,
+    "preventEmptyResponses": false,
+    "hasFeedbacks": false,
+    "options": {
+      "allowComment": false,
+      "allowSkipping": true,
+      "exitButton": false,
+      "logoutButton": false
+    }
+  }
+}

--- a/views/js/test/review/services/navigator/testMap.json
+++ b/views/js/test/review/services/navigator/testMap.json
@@ -1,0 +1,492 @@
+{
+  "title": "Test 12",
+  "identifier": "Test-12",
+  "className": "assessmentTest",
+  "toolName": "tao",
+  "exclusivelyLinear": false,
+  "hasTimeLimits": false,
+  "parts": {
+    "testPart-1": {
+      "id": "testPart-1",
+      "label": "testPart-1",
+      "position": 0,
+      "isLinear": false,
+      "sections": {
+        "assessmentSection-1": {
+          "id": "assessmentSection-1",
+          "label": "Basic section",
+          "position": 0,
+          "items": {
+            "item-1": {
+              "id": "item-1",
+              "label": "Item 1",
+              "position": 0,
+              "positionInPart": 0,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": true,
+              "flagged": false,
+              "viewed": true,
+              "categories" : ["x-tao-option-reviewScreen", "x-tao-option-markReview", "x-tao-option-endTestWarning", "x-tao-option-zoom"],
+              "informational": false
+            },
+            "item-2": {
+              "id": "item-2",
+              "label": "Item 2",
+              "position": 1,
+              "positionInPart": 1,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": true,
+              "flagged": false,
+              "viewed": false,
+              "categories" : ["x-tao-option-reviewScreen", "x-tao-option-markReview", "x-tao-option-endTestWarning", "x-tao-option-zoom"],
+              "informational": false
+            },
+            "item-3": {
+              "id": "item-3",
+              "label": "Item 3",
+              "position": 2,
+              "positionInPart": 2,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : ["x-tao-option-reviewScreen", "x-tao-option-markReview", "x-tao-option-endTestWarning", "x-tao-option-zoom"],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 1,
+            "total": 3
+          }
+        },
+        "assessmentSection-2": {
+          "id": "assessmentSection-2",
+          "label": "Rubric block",
+          "position": 3,
+          "timeConstraint": {
+            "label": "Rubric block",
+            "source": "assessmentSection-2",
+            "seconds": "60",
+            "extraTime": 0,
+            "allowLateSubmission": false,
+            "qtiClassName": "assessmentSection"
+          },
+          "items": {
+            "item-4": {
+              "id": "item-4",
+              "label": "Item 1",
+              "position": 3,
+              "positionInPart": 3,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : ["x-tao-option-calculator", "x-tao-option-zoom", "x-tao-option-foo-bar-baz", "awesome-category"],
+              "informational": false
+            },
+            "item-5": {
+              "id": "item-5",
+              "label": "Item 2",
+              "position": 4,
+              "positionInPart": 4,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : ["x-tao-option-calculator", "x-tao-option-zoom", "x-tao-option-foo-bar-baz", "awesome-category"],
+              "informational": false
+            },
+            "item-6": {
+              "id": "item-6",
+              "label": "Item 3",
+              "position": 5,
+              "positionInPart": 5,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : ["x-tao-option-calculator", "x-tao-option-zoom", "x-tao-option-foo-bar-baz", "awesome-category"],
+              "informational": false,
+              "timeConstraint": {
+                "label": "Item 3",
+                "source": "item-6",
+                "seconds": "20",
+                "extraTime": 0,
+                "allowLateSubmission": false,
+                "qtiClassName": "assessmentItemRef"
+              }
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 3
+          }
+        },
+        "assessmentSection-3": {
+          "id": "assessmentSection-3",
+          "label": "Timed section",
+          "position": 6,
+          "timeConstraint": {
+            "label": "Timed section",
+            "source": "assessmentSection-3",
+            "seconds": "90",
+            "extraTime": 0,
+            "allowLateSubmission": false,
+            "qtiClassName": "assessmentSection"
+          },
+          "items": {
+            "item-7": {
+              "id": "item-7",
+              "label": "Item 1",
+              "position": 6,
+              "positionInPart": 6,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            },
+            "item-8": {
+              "id": "item-8",
+              "label": "Item 2",
+              "position": 7,
+              "positionInPart": 7,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            },
+            "item-9": {
+              "id": "item-9",
+              "label": "Item 3",
+              "position": 8,
+              "positionInPart": 8,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 3
+          }
+        },
+        "assessmentSection-4": {
+          "id": "assessmentSection-4",
+          "label": "Feedback section",
+          "position": 9,
+          "items": {
+            "item-10": {
+              "id": "item-10",
+              "label": "Item 1",
+              "position": 9,
+              "positionInPart": 9,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            },
+            "item-11": {
+              "id": "item-11",
+              "label": "Item 2",
+              "position": 10,
+              "positionInPart": 10,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 2,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 2
+          }
+        },
+        "assessmentSection-5": {
+          "id": "assessmentSection-5",
+          "label": "Jump section",
+          "position": 11,
+          "items": {
+            "item-12": {
+              "id": "item-12",
+              "label": "Item 1",
+              "position": 11,
+              "positionInPart": 11,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            },
+            "item-13": {
+              "id": "item-13",
+              "label": "Item 2",
+              "position": 12,
+              "positionInPart": 12,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            },
+            "item-14": {
+              "id": "item-14",
+              "label": "Item 3",
+              "position": 13,
+              "positionInPart": 13,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "total": 3
+          }
+        }
+      },
+      "stats": {
+        "questions": 14,
+        "answered": 0,
+        "flagged": 0,
+        "viewed": 1,
+        "total": 14
+      }
+    },
+    "testPart-2": {
+      "id": "testPart-2",
+      "label": "testPart-2",
+      "position": 14,
+      "isLinear": true,
+      "sections": {
+        "assessmentSection-6": {
+          "id": "assessmentSection-6",
+          "label": "Section 1",
+          "position": 14,
+          "items": {
+            "item-15": {
+              "id": "item-15",
+              "label": "Item 1",
+              "position": 14,
+              "positionInPart": 0,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": 1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "informational": false
+            },
+            "item-16": {
+              "id": "item-16",
+              "label": "Item 2",
+              "position": 15,
+              "positionInPart": 1,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": 1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "informational": false
+            },
+            "item-17": {
+              "id": "item-17",
+              "label": "Item 3",
+              "position": 16,
+              "positionInPart": 2,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": 1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 3
+          }
+        }
+      },
+      "stats": {
+        "questions": 3,
+        "answered": 0,
+        "flagged": 0,
+        "viewed": 0,
+        "total": 3
+      }
+    }
+  },
+  "jumps": [{
+    "identifier": "item-1",
+    "section": "assessmentSection-1",
+    "part": "testPart-1",
+    "position": 0
+  }, {
+    "identifier": "item-2",
+    "section": "assessmentSection-1",
+    "part": "testPart-1",
+    "position": 1
+  }, {
+    "identifier": "item-3",
+    "section": "assessmentSection-1",
+    "part": "testPart-1",
+    "position": 2
+  }, {
+    "identifier": "item-4",
+    "section": "assessmentSection-2",
+    "part": "testPart-1",
+    "position": 3
+  }, {
+    "identifier": "item-5",
+    "section": "assessmentSection-2",
+    "part": "testPart-1",
+    "position": 4
+  }, {
+    "identifier": "item-6",
+    "section": "assessmentSection-2",
+    "part": "testPart-1",
+    "position": 5
+  }, {
+    "identifier": "item-7",
+    "section": "assessmentSection-3",
+    "part": "testPart-1",
+    "position": 6
+  }, {
+    "identifier": "item-8",
+    "section": "assessmentSection-3",
+    "part": "testPart-1",
+    "position": 7
+  }, {
+    "identifier": "item-9",
+    "section": "assessmentSection-3",
+    "part": "testPart-1",
+    "position": 8
+  }, {
+    "identifier": "item-10",
+    "section": "assessmentSection-4",
+    "part": "testPart-1",
+    "position": 9
+  }, {
+    "identifier": "item-11",
+    "section": "assessmentSection-4",
+    "part": "testPart-1",
+    "position": 10
+  }, {
+    "identifier": "item-12",
+    "section": "assessmentSection-5",
+    "part": "testPart-1",
+    "position": 11
+  }, {
+    "identifier": "item-13",
+    "section": "assessmentSection-5",
+    "part": "testPart-1",
+    "position": 12
+  }, {
+    "identifier": "item-14",
+    "section": "assessmentSection-5",
+    "part": "testPart-1",
+    "position": 13
+  }, {
+    "identifier": "item-15",
+    "section": "assessmentSection-6",
+    "part": "testPart-2",
+    "position": 14
+  }, {
+    "identifier": "item-16",
+    "section": "assessmentSection-6",
+    "part": "testPart-2",
+    "position": 15
+  }, {
+    "identifier": "item-17",
+    "section": "assessmentSection-6",
+    "part": "testPart-2",
+    "position": 16
+  }],
+  "stats": {
+    "questions": 17,
+    "answered": 0,
+    "flagged": 0,
+    "viewed": 1,
+    "total": 17
+  }
+}

--- a/views/js/test/review/services/navigator/testMapFiltered.json
+++ b/views/js/test/review/services/navigator/testMapFiltered.json
@@ -1,0 +1,298 @@
+{
+  "title": "Test 12",
+  "identifier": "Test-12",
+  "className": "assessmentTest",
+  "toolName": "tao",
+  "exclusivelyLinear": false,
+  "hasTimeLimits": false,
+  "parts": {
+    "testPart-1": {
+      "id": "testPart-1",
+      "label": "testPart-1",
+      "position": 0,
+      "isLinear": false,
+      "sections": {
+        "assessmentSection-1": {
+          "id": "assessmentSection-1",
+          "label": "Basic section",
+          "position": 0,
+          "items": {
+            "item-1": {
+              "id": "item-1",
+              "label": "Item 1",
+              "position": 0,
+              "positionInPart": 0,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": true,
+              "flagged": false,
+              "viewed": true,
+              "categories" : ["x-tao-option-reviewScreen", "x-tao-option-markReview", "x-tao-option-endTestWarning", "x-tao-option-zoom"],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 1,
+            "total": 3
+          }
+        },
+        "assessmentSection-2": {
+          "id": "assessmentSection-2",
+          "label": "Rubric block",
+          "position": 3,
+          "timeConstraint": {
+            "label": "Rubric block",
+            "source": "assessmentSection-2",
+            "seconds": "60",
+            "extraTime": 0,
+            "allowLateSubmission": false,
+            "qtiClassName": "assessmentSection"
+          },
+          "items": {
+            "item-6": {
+              "id": "item-6",
+              "label": "Item 3",
+              "position": 5,
+              "positionInPart": 5,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : ["x-tao-option-calculator", "x-tao-option-zoom", "x-tao-option-foo-bar-baz", "awesome-category"],
+              "informational": false,
+              "timeConstraint": {
+                "label": "Item 3",
+                "source": "item-6",
+                "seconds": "20",
+                "extraTime": 0,
+                "allowLateSubmission": false,
+                "qtiClassName": "assessmentItemRef"
+              }
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 3
+          }
+        },
+        "assessmentSection-3": {
+          "id": "assessmentSection-3",
+          "label": "Timed section",
+          "position": 6,
+          "timeConstraint": {
+            "label": "Timed section",
+            "source": "assessmentSection-3",
+            "seconds": "90",
+            "extraTime": 0,
+            "allowLateSubmission": false,
+            "qtiClassName": "assessmentSection"
+          },
+          "items": {
+            "item-8": {
+              "id": "item-8",
+              "label": "Item 2",
+              "position": 7,
+              "positionInPart": 7,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            },
+            "item-9": {
+              "id": "item-9",
+              "label": "Item 3",
+              "position": 8,
+              "positionInPart": 8,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 3
+          }
+        },
+        "assessmentSection-5": {
+          "id": "assessmentSection-5",
+          "label": "Jump section",
+          "position": 11,
+          "items": {
+            "item-14": {
+              "id": "item-14",
+              "label": "Item 3",
+              "position": 13,
+              "positionInPart": 13,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": -1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "categories" : [],
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "total": 3
+          }
+        }
+      },
+      "stats": {
+        "questions": 14,
+        "answered": 0,
+        "flagged": 0,
+        "viewed": 1,
+        "total": 14
+      }
+    },
+    "testPart-2": {
+      "id": "testPart-2",
+      "label": "testPart-2",
+      "position": 14,
+      "isLinear": true,
+      "sections": {
+        "assessmentSection-6": {
+          "id": "assessmentSection-6",
+          "label": "Section 1",
+          "position": 14,
+          "items": {
+            "item-15": {
+              "id": "item-15",
+              "label": "Item 1",
+              "position": 14,
+              "positionInPart": 0,
+              "positionInSection": 0,
+              "index": 1,
+              "occurrence": 0,
+              "remainingAttempts": 1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "informational": false
+            },
+            "item-16": {
+              "id": "item-16",
+              "label": "Item 2",
+              "position": 15,
+              "positionInPart": 1,
+              "positionInSection": 1,
+              "index": 2,
+              "occurrence": 0,
+              "remainingAttempts": 1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "informational": false
+            },
+            "item-17": {
+              "id": "item-17",
+              "label": "Item 3",
+              "position": 16,
+              "positionInPart": 2,
+              "positionInSection": 2,
+              "index": 3,
+              "occurrence": 0,
+              "remainingAttempts": 1,
+              "answered": false,
+              "flagged": false,
+              "viewed": false,
+              "informational": false
+            }
+          },
+          "stats": {
+            "questions": 3,
+            "answered": 0,
+            "flagged": 0,
+            "viewed": 0,
+            "total": 3
+          }
+        }
+      },
+      "stats": {
+        "questions": 3,
+        "answered": 0,
+        "flagged": 0,
+        "viewed": 0,
+        "total": 3
+      }
+    }
+  },
+  "jumps": [{
+    "identifier": "item-1",
+    "section": "assessmentSection-1",
+    "part": "testPart-1",
+    "position": 0
+  }, {}, {}, {}, {}, {
+    "identifier": "item-6",
+    "section": "assessmentSection-2",
+    "part": "testPart-1",
+    "position": 5
+  }, {}, {
+    "identifier": "item-8",
+    "section": "assessmentSection-3",
+    "part": "testPart-1",
+    "position": 7
+  }, {
+    "identifier": "item-9",
+    "section": "assessmentSection-3",
+    "part": "testPart-1",
+    "position": 8
+  }, {}, {}, {}, {}, {
+    "identifier": "item-14",
+    "section": "assessmentSection-5",
+    "part": "testPart-1",
+    "position": 13
+  }, {
+    "identifier": "item-15",
+    "section": "assessmentSection-6",
+    "part": "testPart-2",
+    "position": 14
+  }, {
+    "identifier": "item-16",
+    "section": "assessmentSection-6",
+    "part": "testPart-2",
+    "position": 15
+  }, {
+    "identifier": "item-17",
+    "section": "assessmentSection-6",
+    "part": "testPart-2",
+    "position": 16
+  }],
+  "stats": {
+    "questions": 17,
+    "answered": 0,
+    "flagged": 0,
+    "viewed": 1,
+    "total": 17
+  }
+}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8928

Make the navigator service compatible with filtered test maps.
As the jumps table might contains gaps when the test maps is filtered, the navigator service must be able to jump over those gaps while moving forward and backward along the test.
The navigator service supplied by the test runner has been extended.
The test runner is also now emitting a `testmapchange` event each time the test map get updated. This allows the plugins to adapt their UI accordingly.

Impacted unit test:
- `taoReview/views/js/test/review/component/qtiTestReviewComponent/test.html`
- `taoReview/views/js/test/review/plugins/navigation/next-prev/plugin/test.html`
- `taoReview/views/js/test/review/plugins/navigation/review-panel/plugin/test.html`
- `taoReview/views/js/test/review/provider/qtiTestReviewProvider/test.html`
- `taoReview/views/js/test/review/services/navigator/test.html`

To launch tests:
```
cd tao/views/build
npx grunt connect:dev taoreviewtest
```
