### PR TITLE
Fix/wrong bundle dependency

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.6.0',
+    'version' => '1.6.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -68,6 +68,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.6.0');
         }
 
-        $this->skip('0.6.0', '1.6.0');
+        $this->skip('0.6.0', '1.6.1');
     }
 }

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -35,6 +35,14 @@ module.exports = function(grunt) {
                         babel : true,
                         include : [
                             'taoReview/review/**/*'
+                        ],
+                        dependencies : [
+                            'taoItems/loader/taoItemsRunner.min',
+                            'taoTests/loader/taoTestsRunner.min',
+                            'taoQtiItem/loader/taoQtiItemRunner.min',
+                            'taoQtiTest/loader/taoQtiTestRunner.min',
+                            'taoQtiTest/loader/testPlugins.min',
+                            'taoQtiTestPreviewer/loader/qtiPreviewer.min'
                         ]
                     }]
                 }


### PR DESCRIPTION
Fix a bundle issue in the javascript. A wrong path has been set to the `taoQtiTestPreviewer` bundle.

To test, set the instance on production mode, then run the testReview.
After bundling, the issue should have gone.

To bundle:
```
cd tao/views/build
npx grunt taoreviewbundle
```