### PR TITLE
Add correct item responses from previewer

### DIFF
--- a/controller/Review.php
+++ b/controller/Review.php
@@ -120,7 +120,12 @@ class Review extends tao_actions_SinglePageModule
 
         $itemData = $itemPreviewer->loadCompiledItemData();
 
-        $itemData['data']['responses'] = $itemPreviewer->loadCompiledItemVariables();
+        if (!empty($itemData['data']['responses'])) {
+            $itemData['data']['responses'] = array_merge_recursive(...[
+                $itemData['data']['responses'],
+                $itemPreviewer->loadCompiledItemVariables()
+            ]);
+        }
 
         $response['content'] = $itemData;
         $response['baseUrl'] = $itemPreviewer->getBaseUrl();

--- a/controller/Review.php
+++ b/controller/Review.php
@@ -105,7 +105,7 @@ class Review extends tao_actions_SinglePageModule
         $deliveryExecutionId = $params['serviceCallId'];
         $itemDefinition = $params['itemUri'];
 
-        /** @var DeliveryExecutionManagerService $des */
+        /** @var DeliveryExecutionManagerService $deManagerService */
         $deManagerService = $this->getServiceLocator()->get(DeliveryExecutionManagerService::SERVICE_ID);
         $execution = $deManagerService->getDeliveryExecutionById($deliveryExecutionId);
         $delivery = $execution->getDelivery();
@@ -113,11 +113,16 @@ class Review extends tao_actions_SinglePageModule
         $itemPreviewer = new ItemPreviewer();
         $itemPreviewer->setServiceLocator($this->getServiceLocator());
 
-        $response['content'] = $itemPreviewer->setItemDefinition($itemDefinition)
+        $itemPreviewer
+            ->setItemDefinition($itemDefinition)
             ->setUserLanguage($this->getUserLanguage($deliveryExecutionId, $delivery->getUri()))
-            ->setDelivery($delivery)
-            ->loadCompiledItemData();
+            ->setDelivery($delivery);
 
+        $itemData = $itemPreviewer->loadCompiledItemData();
+
+        $itemData['data']['responses'] = $itemPreviewer->loadCompiledItemVariables();
+
+        $response['content'] = $itemData;
         $response['baseUrl'] = $itemPreviewer->getBaseUrl();
         $response['success'] = true;
 

--- a/manifest.php
+++ b/manifest.php
@@ -29,13 +29,14 @@ return [
     'label' => 'Review',
     'description' => 'Extension for reviewing passed tests, with the display of actual and correct answers.',
     'license' => 'GPL-2.0',
-    'version' => '1.9.0',
+    'version' => '1.10.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.6.0',
         'taoLti' => '>=10.1.0',
         'ltiDeliveryProvider' => '>=9.2.0',
         'taoQtiTest' => '>=34.6.0',
+        'taoQtiTestPreviewer' => '>=2.8.0'
     ],
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoReviewManager',
     'acl' => [

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -19,6 +19,7 @@
 
 namespace oat\taoReview\models;
 
+use core_kernel_classes_Resource;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
 use oat\oatbox\service\ConfigurableService;
@@ -53,9 +54,16 @@ class DeliveryExecutionFinderService extends ConfigurableService
         $launchDataService = $this->getLaunchDataService();
         $ltiResultIdStorage = $this->getLtiResultIdStorage();
 
-        $resultIdentifier = $launchData->hasVariable(self::LTI_SOURCE_ID)
-            ? $launchData->getVariable(self::LTI_SOURCE_ID)
-            : $launchDataService->findDeliveryExecutionFromLaunchData($launchData);
+        /** @var core_kernel_classes_Resource $execution */
+        $execution = $launchDataService->findDeliveryExecutionFromLaunchData($launchData);
+
+        if ($execution && $execution->exists()) {
+            $resultIdentifier = $execution->getUri();
+        } else {
+            $resultIdentifier = $launchData->hasVariable(self::LTI_SOURCE_ID)
+                ? $launchData->getVariable(self::LTI_SOURCE_ID)
+                : null;
+        }
 
         $deliveryExecutionId = $ltiResultIdStorage->getDeliveryExecutionId($resultIdentifier);
 

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -109,9 +109,11 @@ class DeliveryExecutionFinderService extends ConfigurableService
             : false;
 
         if (is_numeric($value)) {
-            $value = (bool)intval($value);
-        } else if ($value == 'true') {
+            $value = (bool)(int)$value;
+        } else if ($value === 'true') {
             $value = true;
+        } else {
+            $value = false;
         }
 
         return $value;

--- a/models/DeliveryExecutionFinderService.php
+++ b/models/DeliveryExecutionFinderService.php
@@ -108,15 +108,7 @@ class DeliveryExecutionFinderService extends ConfigurableService
             ? $launchData->getVariable($option)
             : false;
 
-        if (is_numeric($value)) {
-            $value = (bool)(int)$value;
-        } else if ($value === 'true') {
-            $value = true;
-        } else {
-            $value = false;
-        }
-
-        return $value;
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 
     protected function getLtiResultIdStorage(): LtiResultAliasStorage

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -68,6 +68,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.6.0');
         }
 
-        $this->skip('0.6.0', '1.9.0');
+        $this->skip('0.6.0', '1.10.0');
     }
 }


### PR DESCRIPTION
Task https://oat-sa.atlassian.net/browse/TAO-8942

Depends on https://github.com/oat-sa/extension-tao-testqti-previewer/pull/33

This PR include the next changes:
- now it requires `taoQtiTestPreviewer` extension as it called inside.
- correct responses fetched from compiled data and merged with item definition.
- changed the way of getting results. Now GET parameter `execution` has higher priority than `lis_result_sourcedid`, but the latest still work to keep backward compatibility.

How to test: run any test and after that, using LTI tools, run it in the review mode and set custom parameter `show_correct` as `true` or `1`.